### PR TITLE
Allow lock start times to be edited; create reservations a week in advance.

### DIFF
--- a/backend/lambdas/shared/scheduler/scheduler.go
+++ b/backend/lambdas/shared/scheduler/scheduler.go
@@ -163,8 +163,8 @@ func (s *Scheduler) getRelevantReservations(reservations []shared.Reservation) (
 			continue // If it ended an hour or more ago, ignore it.
 		}
 
-		if r.Start.After(s.now.Add(1 * time.Hour)) {
-			continue // If it starts more than an hour in the future, ignore it.
+		if r.Start.After(s.now.Add(24 * 7 * time.Hour)) {
+			continue // If it starts more than a week in the future, ignore it.
 		}
 
 		// We don't control the IDs, so it's probably a good idea to double check that they're unique (at least within a unit's active reservations).


### PR DESCRIPTION
Testing:
* very little - will test with upcoming FE changes.

https://github.com/anthonywittig/mLock/issues/44