### PR TITLE
Lock code creation/deletion updates.

### DIFF
--- a/backend/lambdas/shared/ical/reservation/reservation.go
+++ b/backend/lambdas/shared/ical/reservation/reservation.go
@@ -223,7 +223,7 @@ func parseReservations(data string) ([]shared.Reservation, error) {
 	i++
 
 	if i != len(lines) {
-		return nil, fmt.Errorf("line lenght doesn't _line_ up")
+		return nil, fmt.Errorf("line length doesn't _line_ up")
 	}
 
 	return reservations, nil

--- a/backend/lambdas/shared/lockengine/lockengine.go
+++ b/backend/lambdas/shared/lockengine/lockengine.go
@@ -61,7 +61,6 @@ func (l *LockEngine) UpdateLocks(ctx context.Context) error {
 
 	now := time.Now()
 	nearPast := now.Add(-1 * time.Hour * 24 * 7)
-	minPastCount := 5
 
 	for _, d := range ds {
 		lockStates := l.getLockStates(now, d)
@@ -72,7 +71,6 @@ func (l *LockEngine) UpdateLocks(ctx context.Context) error {
 		}
 
 		nonDeletedMLCs := []*shared.DeviceManagedLockCode{}
-		completedMLCsCount := 0
 
 		for i, mlc := range d.ManagedLockCodes {
 			if mlc.EndAt.Before(nearPast) && mlc.Status == shared.DeviceManagedLockCodeStatus5Complete {
@@ -84,12 +82,9 @@ func (l *LockEngine) UpdateLocks(ctx context.Context) error {
 					}
 				}
 				if !justUpdated {
-					completedMLCsCount = completedMLCsCount + 1
-					if completedMLCsCount >= minPastCount {
-						d.ManagedLockCodes[i].Note = "Deleting code as it completed a while ago."
-						needToSave = append(needToSave, d.ManagedLockCodes[i])
-						continue
-					}
+					d.ManagedLockCodes[i].Note = "Deleting code as it completed a while ago."
+					needToSave = append(needToSave, d.ManagedLockCodes[i])
+					continue
 				}
 			}
 			nonDeletedMLCs = append(nonDeletedMLCs, d.ManagedLockCodes[i])

--- a/backend/lambdas/shared/lockengine/lockengine_test.go
+++ b/backend/lambdas/shared/lockengine/lockengine_test.go
@@ -208,28 +208,35 @@ func Test_deleteOneButNotAllMLCs(t *testing.T) {
 	device := shared.Device{
 		ID: uuid.New(),
 		ManagedLockCodes: []*shared.DeviceManagedLockCode{
-			// Old enough to delete, but since we keep the x most recent it'll hang out.
+			// Expect to be deleted.
 			{
 				Code:    "0001",
 				EndAt:   time.Now().Add(-1 * time.Hour * 24 * 8),
 				Status:  shared.DeviceManagedLockCodeStatus5Complete,
 				StartAt: time.Now().Add(-1 * time.Hour * 24 * 9),
 			},
-			// Old enough to delete, but since we keep the x most recent it'll hang out.
+			// Expect to be deleted.
 			{
 				Code:    "0002",
 				EndAt:   time.Now().Add(-1 * time.Hour * 24 * 9),
 				Status:  shared.DeviceManagedLockCodeStatus5Complete,
 				StartAt: time.Now().Add(-1 * time.Hour * 24 * 10),
 			},
-			// Old enough to delete, but since we keep the x most recent it'll hang out.
+			// Don't delete because it's not a week old.
+			{
+				Code:    "9999",
+				EndAt:   time.Now().Add(-1 * time.Hour * 24 * 1),
+				Status:  shared.DeviceManagedLockCodeStatus5Complete,
+				StartAt: time.Now().Add(-1 * time.Hour * 24 * 2),
+			},
+			// Expect to be deleted.
 			{
 				Code:    "0003",
 				EndAt:   time.Now().Add(-1 * time.Hour * 24 * 10),
 				Status:  shared.DeviceManagedLockCodeStatus5Complete,
 				StartAt: time.Now().Add(-1 * time.Hour * 24 * 11),
 			},
-			// Old enough to delete, but since we keep the x most recent it'll hang out.
+			// Expect to be deleted.
 			{
 				Code:    "0004",
 				EndAt:   time.Now().Add(-1 * time.Hour * 24 * 11),
@@ -250,13 +257,6 @@ func Test_deleteOneButNotAllMLCs(t *testing.T) {
 				Status:  shared.DeviceManagedLockCodeStatus5Complete,
 				StartAt: time.Now().Add(-1 * time.Hour * 24 * 14),
 			},
-			// Don't delete because it's not a week old.
-			{
-				Code:    "9999",
-				EndAt:   time.Now().Add(-1 * time.Hour * 24 * 1),
-				Status:  shared.DeviceManagedLockCodeStatus5Complete,
-				StartAt: time.Now().Add(-1 * time.Hour * 24 * 2),
-			},
 		},
 		RawDevice: shared.RawDevice{},
 	}
@@ -275,22 +275,22 @@ func Test_deleteOneButNotAllMLCs(t *testing.T) {
 	).Do(func(ctx context.Context, d shared.Device, managedLockCodes []*shared.DeviceManagedLockCode) {
 		assert.Equal(t, device.ID, d.ID)
 
-		assert.Equal(t, 5, len(d.ManagedLockCodes))
+		assert.Equal(t, 1, len(d.ManagedLockCodes))
 		mlc := d.ManagedLockCodes[0]
-		assert.Equal(t, "0001", mlc.Code)
-		mlc = d.ManagedLockCodes[1]
-		assert.Equal(t, "0002", mlc.Code)
-		mlc = d.ManagedLockCodes[2]
-		assert.Equal(t, "0003", mlc.Code)
-		mlc = d.ManagedLockCodes[3]
-		assert.Equal(t, "0004", mlc.Code)
-		mlc = d.ManagedLockCodes[4]
 		assert.Equal(t, "9999", mlc.Code)
 
-		assert.Equal(t, 2, len(managedLockCodes))
+		assert.Equal(t, 6, len(managedLockCodes))
 		mlc = managedLockCodes[0]
-		assert.Equal(t, "0005", mlc.Code)
+		assert.Equal(t, "0001", mlc.Code)
 		mlc = managedLockCodes[1]
+		assert.Equal(t, "0002", mlc.Code)
+		mlc = managedLockCodes[2]
+		assert.Equal(t, "0003", mlc.Code)
+		mlc = managedLockCodes[3]
+		assert.Equal(t, "0004", mlc.Code)
+		mlc = managedLockCodes[4]
+		assert.Equal(t, "0005", mlc.Code)
+		mlc = managedLockCodes[5]
 		assert.Equal(t, "0006", mlc.Code)
 	}).Return(nil)
 
@@ -299,16 +299,8 @@ func Test_deleteOneButNotAllMLCs(t *testing.T) {
 		gomock.Any(),
 	).Do(func(ctx context.Context, d shared.Device) {
 		assert.Equal(t, d.ID, d.ID)
-		assert.Equal(t, 5, len(d.ManagedLockCodes))
+		assert.Equal(t, 1, len(d.ManagedLockCodes))
 		mlc := d.ManagedLockCodes[0]
-		assert.Equal(t, "0001", mlc.Code)
-		mlc = d.ManagedLockCodes[1]
-		assert.Equal(t, "0002", mlc.Code)
-		mlc = d.ManagedLockCodes[2]
-		assert.Equal(t, "0003", mlc.Code)
-		mlc = d.ManagedLockCodes[3]
-		assert.Equal(t, "0004", mlc.Code)
-		mlc = d.ManagedLockCodes[4]
 		assert.Equal(t, "9999", mlc.Code)
 	}).Return(shared.Device{}, nil)
 

--- a/backend/lambdas/shared/scheduler/scheduler.go
+++ b/backend/lambdas/shared/scheduler/scheduler.go
@@ -163,10 +163,6 @@ func (s *Scheduler) getRelevantReservations(reservations []shared.Reservation) (
 			continue // If it ended an hour or more ago, ignore it.
 		}
 
-		if r.Start.After(s.now.Add(24 * 7 * time.Hour)) {
-			continue // If it starts more than a week in the future, ignore it.
-		}
-
 		// We don't control the IDs, so it's probably a good idea to double check that they're unique (at least within a unit's active reservations).
 		if _, ok := relevantReservations[r.ID]; ok {
 			return nil, fmt.Errorf("duplicate reservation found, reservation ID: %s", r.ID)


### PR DESCRIPTION
Testing:
* build/tests
* saw new codes created for reservations further than a week out created
* saw reservations older than a week deleted